### PR TITLE
Exponential backof

### DIFF
--- a/src/rabbit-lru-cache.ts
+++ b/src/rabbit-lru-cache.ts
@@ -2,10 +2,9 @@ import * as LRUCache from "lru-cache";
 import { connect, Options, ConsumeMessage, Channel, Connection } from "amqplib";
 import * as uuid from "uuid";
 import { ClosingError } from "./errors/ClosingError";
-import { notEqual } from "assert";
+import * as assert from "assert";
 import { EventEmitter } from "events";
 import once from "./utils/once";
-import assert = require("assert");
 
 export type RabbitLRUCache<T> = {
     close: () => Promise<void>;
@@ -54,11 +53,11 @@ const reconnectionOptionsDefault: Required<ReconnectionOptions> = {
 }
 
 export async function createRabbitLRUCache<T>(options: RabbitLRUCacheOptions<T>): Promise<RabbitLRUCache<T>> {
-    notEqual(options, null, "options is required");
-    notEqual(options.name, null, "options.name is required");
-    notEqual(options.name, "", "options.name is required");
-    notEqual(options.LRUCacheOptions, null, "options.LRUCacheOptions is required");
-    notEqual(options.amqpConnectOptions, null, "options.amqpConnectOptions is required");
+    assert.notEqual(options, null, "options is required");
+    assert.notEqual(options.name, null, "options.name is required");
+    assert.notEqual(options.name, "", "options.name is required");
+    assert.notEqual(options.LRUCacheOptions, null, "options.LRUCacheOptions is required");
+    assert.notEqual(options.amqpConnectOptions, null, "options.amqpConnectOptions is required");
     assert(!options.reconnectionOptions || !options.reconnectionOptions.retryMethod || ["incremental", "exponential"].includes(options.reconnectionOptions.retryMethod), "options.reconnectionOptions.retryMethod should be one of 'increment' or 'exponential'");
 
     const eventEmitter = new EventEmitter();
@@ -279,7 +278,7 @@ export async function createRabbitLRUCache<T>(options: RabbitLRUCacheOptions<T>)
             await connection.close();
             cache.reset();
         },
-        prune() {
+        prune(): void {
             assertIsClosingOrClosed();
             cache.prune();
         },

--- a/src/rabbit-lru-cache.ts
+++ b/src/rabbit-lru-cache.ts
@@ -36,15 +36,15 @@ export type RabbitLRUCacheOptions<T> = {
 
 type ReconnectionOptions = {
     allowStaleData?: boolean;
-    retryIntervalUpTo?: number;
-    retryBase?: number;
+    retryMaxInterval?: number;
+    retryMinInterval?: number;
     retryFactor?: number;
 };
 
 const reconnectionOptionsDefault: Required<ReconnectionOptions> = {
     allowStaleData: false,
-    retryIntervalUpTo: 60,
-    retryBase: 0,
+    retryMaxInterval: 60000,
+    retryMinInterval: 1000,
     retryFactor: 2
 }
 
@@ -129,10 +129,8 @@ export async function createRabbitLRUCache<T>(options: RabbitLRUCacheOptions<T>)
     }
 
     function getRetryInterval(attempt: number): number {
-        const { retryIntervalUpTo, retryBase, retryFactor } = reconnectionOptions;
-        const retryInterval = Math.pow(retryFactor, attempt) * 1000;
-        
-        return Math.min(retryBase + retryInterval, retryIntervalUpTo * 1000);
+        const { retryMinInterval, retryMaxInterval, retryFactor } = reconnectionOptions;
+        return Math.min(retryMinInterval * Math.pow(retryFactor, attempt), retryMaxInterval);
     }
 
     async function handleConnectionError(error: Error, attempt = 0): Promise<void> {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -902,8 +902,10 @@ describe("rabbit-lru-cache", () => {
             }
             cache.addReconnectedListener(onReconnectedEvent);
 
-            const reconnectionError1 = Error("RabbitMq error reconnecting 1");
-            connectMock.mockRejectedValueOnce(reconnectionError1);
+            const reconnectionError = Error("RabbitMq error reconnecting");
+            connectMock
+                .mockRejectedValueOnce(reconnectionError)
+                .mockRejectedValueOnce(reconnectionError);
 
             // Act
             const connectionError = Error("RabbitMq is gone");
@@ -949,8 +951,10 @@ describe("rabbit-lru-cache", () => {
             }
             cache.addReconnectedListener(onReconnectedEvent);
 
-            const reconnectionError1 = Error("RabbitMq error reconnecting 1");
-            connectMock.mockRejectedValueOnce(reconnectionError1);
+            const reconnectionError = Error("RabbitMq error reconnecting");
+            connectMock
+                .mockRejectedValueOnce(reconnectionError)
+                .mockRejectedValueOnce(reconnectionError);
 
             // Act
             const connectionError = Error("RabbitMq is gone");

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -119,27 +119,6 @@ describe("rabbit-lru-cache", () => {
         }
     });
 
-    it("should throw an assert error if options.reconnectionOptions.retryMethod is not 'exponential' neither 'increment'", async () => {
-        // Arrange
-        expect.assertions(2);
-
-        // Act
-        try {
-            const createRabbitLRUCache = requireRabbitLRUCache<string>();
-            await createRabbitLRUCache({
-                name: "test",
-                LRUCacheOptions: { },
-                amqpConnectOptions,
-                reconnectionOptions: {
-                    retryMethod: "non-existing-retry-method" as any
-                }
-            });
-        } catch(error) {
-            expect(error instanceof AssertionError).toBe(true);
-            expect(error.message).toBe("options.reconnectionOptions.retryMethod should be one of 'increment' or 'exponential'");
-        }
-    });
-
     it("should invalidate cache key on del key", async () => {
         // Arrange
         let cache1: RabbitLRUCache<string> | null = null;
@@ -855,7 +834,6 @@ describe("rabbit-lru-cache", () => {
                 LRUCacheOptions: {},
                 amqpConnectOptions,
                 reconnectionOptions: {
-                    retryIntervalIncrease: 1,
                     retryIntervalUpTo: 1
                 }
             });
@@ -908,7 +886,7 @@ describe("rabbit-lru-cache", () => {
                 LRUCacheOptions: {},
                 amqpConnectOptions,
                 reconnectionOptions: {
-                    retryMethod: 'exponential'
+                    retryFactor: 3
                 }
             });
 
@@ -940,7 +918,7 @@ describe("rabbit-lru-cache", () => {
 
             expect(reconnectedError).toBe(reconnectionError2);
             expect(reconnectedAttempt).toBe(3);
-            expect(reconnectedRetryInterval).toBe(4000);
+            expect(reconnectedRetryInterval).toBe(9000);
         } finally {
             await cache?.close();
             jest.unmock("amqplib");

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -119,6 +119,27 @@ describe("rabbit-lru-cache", () => {
         }
     });
 
+    it("should throw an assert error if options.reconnectionOptions.retryMethod is not 'exponential' neither 'increment'", async () => {
+        // Arrange
+        expect.assertions(2);
+
+        // Act
+        try {
+            const createRabbitLRUCache = requireRabbitLRUCache<string>();
+            await createRabbitLRUCache({
+                name: "test",
+                LRUCacheOptions: { },
+                amqpConnectOptions,
+                reconnectionOptions: {
+                    retryMethod: "non-existing-retry-method" as any
+                }
+            });
+        } catch(error) {
+            expect(error instanceof AssertionError).toBe(true);
+            expect(error.message).toBe("options.reconnectionOptions.retryMethod should be one of 'increment' or 'exponential'");
+        }
+    });
+
     it("should invalidate cache key on del key", async () => {
         // Arrange
         let cache1: RabbitLRUCache<string> | null = null;


### PR DESCRIPTION
Hi @francescorivola, i have prepared this PR implementing exponential backoff. 

Take into account that this PR includes a breaking change:

- retryIntervalUpTo and retryIntervalIncrease should be expressed in seconds (instead mili seconds).

This is because the calc we need to do in exponential backoff and to keep it simply. Otherwise we can think in introduce a retryMultiplier or similar, to calculate exponential backoff (it could be 1000 by default). 

What do you think?